### PR TITLE
Fix plotting trajectories also for highD

### DIFF
--- a/lxd_io/recording.py
+++ b/lxd_io/recording.py
@@ -266,12 +266,12 @@ class Recording:
                         self._background_image_scale_factor,
                     )
 
-                    ax.plot(
-                        background_image_trajectory[:, 0],
-                        background_image_trajectory[:, 1],
-                        color="red",
-                        linewidth=2,
-                    )
+                ax.plot(
+                    background_image_trajectory[:, 0],
+                    background_image_trajectory[:, 1],
+                    color="red",
+                    linewidth=2,
+                )
 
             ax.axis("off")
             f.savefig(plot_file, bbox_inches="tight", pad_inches=0)


### PR DESCRIPTION
When using highD data to plot multiply trajectories, trajectories would not appear in the image.
This was due to the plotting call being indented to the if-case of the plot setup for non-highD datasets.
Adapting the indentation should fix this for highD without affecting other datasets.

(Only tested with highD-data, but change should not affect other datasets.)